### PR TITLE
Redirect home to 2025 edition of BSidesLuxembourg

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <html>
   <head>
-    <meta http-equiv="refresh" content="0; url=/2019" />
+    <meta http-equiv="refresh" content="0; url=https://www.bsides.lu" />
   </head>
 </html>


### PR DESCRIPTION
Hello,

We're currently running a CFP and gathering sponsor interest for the 2025 edition of BSides Luxembourg. It would help us greatly to have at least this redirection set up as that page is what Google references for the search term "BSides Luxembourg":

[Screencast_20250126_125350.webm](https://github.com/user-attachments/assets/28c62df8-b5a7-4d28-88cc-1b8ea7ed259f)

Thanks